### PR TITLE
Add async types to the Validator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,5 @@ os:
 node_js:
   - "8"
   - "7"
-  - "6"
 script:
   - npm run coverage

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ validator.catch(errors => {
   - [Custom types](#custom-types)
     - [Avanced types](#avanced-types)
     - [Mutate value from within type](#mutate-value-from-within-type)
+    - [Asynchronous types](#asynchronous-types)
   - [Validator](#validator)
 
 
@@ -341,6 +342,22 @@ function string({ defaultValue }) {
   return value => {
     if (defaultValue && (value === undefined || value === null)) {
       throw new Value(defaultValue)
+    }
+
+    return true
+  }
+}
+```
+
+### Asynchronous types
+Specla validator supports asynchronous validator functions like below.
+This enables you to query a database for a validation result or maybe validate a
+hash or something else that is running asynchronously.
+```js
+function uniqueEmail() {
+  return async value => {
+    if (await db.collection('users').count({ email: value })) {
+      throw new Error('There is already a user registered with this email.')
     }
 
     return true

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Standard - JavaScript Style Guide](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/)
 [![gzip size](http://img.badgesize.io/https://unpkg.com/@specla/validator/dist/validator.min.js?compression=gzip)](https://unpkg.com/@specla/validator/dist/validator.min.js)
 
-A `3 kb` gzipped schema validator, built for developers, with extensibility and performance in mind.
+A `4 kb` gzipped schema validator, built for developers, with extensibility and performance in mind.
 It handles both synchronous and asynchronous validation and it is compatible
 with Node.js and Browser environments out of the box.
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ with Node.js and Browser environments out of the box.
 import Validator, { string, number } from '@specla/validator'
 
 const schema = {
-  name: string(),
+  name: String,
   email: async value => await db.collection('users').count({ email: value }), // will validate the email doesn't already exist in DB
+  age: value => value > 16,
   skills: [{
-    type: string(),
+    type: string({ max: 255 }),
     experience: number({ min: 0, max: 10 })
   }],
   createdAt: Date
@@ -27,6 +28,7 @@ const schema = {
 const data = {
   name: 'John Doe',
   email: 'test@example.com',
+  age: 23,
   skills: [{
     type: 'Validation',
     experience: 10

--- a/lib/Validator.js
+++ b/lib/Validator.js
@@ -3,19 +3,20 @@ const { Schema, Value } = require('./exceptions')
 
 module.exports = class Validator {
   /**
-   * Create a new instance of the Validator
+   * Create a new instance of the Validator and return an enhanced promise
    * @param  {Mixed} value
    * @param  {Object|Array|Function} type
    * @param  {Object} options
-   * @return {Validator}
+   * @return {Promise}
    */
   constructor (value, type, options = {}) {
     this.onError = options.onError
-    this.transform = options.transform !== false
     this.errors = {}
     this.mutated = {}
-    this.compare(value, this.transform ? transformType(type) : type)
+    this.promises = []
+    this.compare(value, transformType(type))
     this.mutateData(value)
+    return this.createPromise(value)
   }
 
   /**
@@ -70,6 +71,10 @@ module.exports = class Validator {
    * @private
    */
   compare (value, type, context = []) {
+    if (type.constructor.name === 'AsyncFunction') {
+      return this.promises.push([context, type(value), value])
+    }
+
     if (Array.isArray(type)) {
       return this.compareArray(value, type, context)
     }
@@ -81,16 +86,27 @@ module.exports = class Validator {
     try {
       if (!type(value)) throw new Error('value is invalid')
     } catch (err) {
-      if (err instanceof Schema) {
-        return this.compare(value, transformType(err.schema), context)
-      }
-
-      if (err instanceof Value) {
-        return (this.mutated[context.join('.')] = err.value)
-      }
-
-      this.setError(context, err.message, value)
+      this.handleException(context, err, value)
     }
+  }
+
+  /**
+   * Handle exceptions
+   * @param  {Array} context
+   * @param  {Object} err
+   * @param  {Mixed} value
+   * @private
+   */
+  handleException (context, err, value) {
+    if (err instanceof Schema) {
+      return this.compare(value, transformType(err.schema), context)
+    }
+
+    if (err instanceof Value) {
+      return (this.mutated[context.join('.')] = err.value)
+    }
+
+    this.setError(context, err.message, value)
   }
 
   /**
@@ -134,11 +150,79 @@ module.exports = class Validator {
   }
 
   /**
-   * Check if the validator has failed.
+   * Check if the validator has failed, only works with synchronous schemas.
    * @return {Boolean}
    * @public
    */
   fails () {
+    if (this.promises.length > 0) {
+      throw new Error('The validator is asynchronous use .then() and .catch()')
+    }
+
     return Object.keys(this.errors).length > 0
+  }
+
+  /**
+   * Get errors if the validator is synchronous
+   * @return {Object}
+   * @public
+   */
+  getErrors () {
+    if (this.promises.length > 0) {
+      throw new Error(
+        'The validator is asynchronous use validator.catch() to retrieve errors'
+      )
+    }
+
+    return this.errors
+  }
+
+  /**
+   * Create the return promise with some enhancements
+   * @param  {Mixed} value
+   * @return {Promise} The enhanced validator promise
+   * @private
+   */
+  createPromise (value) {
+    const promise = new Promise((resolve, reject) => {
+      if (this.promises.length === 0) {
+        if (this.fails()) {
+          return reject(this.errors)
+        } else {
+          return resolve(value)
+        }
+      }
+
+      this.waitForPromises()
+        .then(() =>
+          resolve(value)
+        ).catch(() =>
+          reject(this.errors)
+        )
+    })
+
+    promise._validator = this
+    promise.fails = this.fails.bind(this)
+    promise.__defineGetter__('errors', this.getErrors.bind(this))
+    promise.catch(() => {})
+
+    return promise
+  }
+
+  /**
+   * Wait for all promises to resolve or reject
+   * @return {Promise}
+   * @private
+   */
+  waitForPromises () {
+    const promises = this.promises.reduce(
+      (promises, [context, promise, value]) => {
+        promise.catch(err => this.handleException(context, err, value))
+        return promises.concat(promises, promise)
+      },
+      []
+    )
+
+    return Promise.all(promises)
   }
 }

--- a/lib/Validator.js
+++ b/lib/Validator.js
@@ -156,7 +156,7 @@ module.exports = class Validator {
    */
   fails () {
     if (this.promises.length > 0) {
-      throw new Error('The validator is asynchronous use .then() and .catch()')
+      throw new Error('The validator is asynchronous, use .then() and .catch()')
     }
 
     return Object.keys(this.errors).length > 0
@@ -170,7 +170,7 @@ module.exports = class Validator {
   getErrors () {
     if (this.promises.length > 0) {
       throw new Error(
-        'The validator is asynchronous use validator.catch() to retrieve errors'
+        'The validator is asynchronous, use validator.catch() to retrieve errors'
       )
     }
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@specla/validator",
   "version": "1.1.0",
   "homepage": "https://github.com/Specla/Validator#readme",
-  "description": "Super fast, 3 kb Schema validator for Node.js and the Browsers",
+  "description": "Fast 4 kb Schema validator for Node.js and the Browsers",
   "main": "./dist/validator.js",
   "module": "./dist/validator.js",
   "scripts": {

--- a/test/Validator.js
+++ b/test/Validator.js
@@ -138,14 +138,14 @@ describe('Validator', () => {
   it('.fails() should throw an exception if the schema is async', () => {
     const validator = new Validator('test', async value => {})
     expect(() => validator.fails()).throw(
-      'The validator is asynchronous use .then() and .catch()'
+      'The validator is asynchronous, use .then() and .catch()'
     )
   })
 
   it('.errors should throw an exception if the schema is async', () => {
     const validator = new Validator('test', async value => {})
     expect(() => validator.errors).throw(
-      'The validator is asynchronous use validator.catch() to retrieve errors'
+      'The validator is asynchronous, use validator.catch() to retrieve errors'
     )
   })
 

--- a/test/Validator.js
+++ b/test/Validator.js
@@ -135,66 +135,61 @@ describe('Validator', () => {
     })
   })
 
-  /**
-   * Async functions only runs from v7 and up
-   */
-  if (process.version != 'v6') { // eslint-disable-line
-    it('.fails() should throw an exception if the schema is async', () => {
-      const validator = new Validator('test', async value => {})
-      expect(() => validator.fails()).throw(
-        'The validator is asynchronous use .then() and .catch()'
-      )
-    })
+  it('.fails() should throw an exception if the schema is async', () => {
+    const validator = new Validator('test', async value => {})
+    expect(() => validator.fails()).throw(
+      'The validator is asynchronous use .then() and .catch()'
+    )
+  })
 
-    it('.errors should throw an exception if the schema is async', () => {
-      const validator = new Validator('test', async value => {})
-      expect(() => validator.errors).throw(
-        'The validator is asynchronous use validator.catch() to retrieve errors'
-      )
-    })
+  it('.errors should throw an exception if the schema is async', () => {
+    const validator = new Validator('test', async value => {})
+    expect(() => validator.errors).throw(
+      'The validator is asynchronous use validator.catch() to retrieve errors'
+    )
+  })
 
-    it('Should wait for async validation types', function (done) {
-      this.slow(1000)
-      const data = { key: 'testing' }
-      const schema = {
-        key: async value => {
-          await sleep(100)
+  it('Should wait for async validation types', function (done) {
+    this.slow(1000)
+    const data = { key: 'testing' }
+    const schema = {
+      key: async value => {
+        await sleep(100)
 
-          if (typeof value !== 'string') {
-            throw new Error('should be a string')
-          }
-
-          return true
+        if (typeof value !== 'string') {
+          throw new Error('should be a string')
         }
+
+        return true
       }
+    }
 
-      const validator = new Validator(data, schema)
-      validator.then(value => {
-        expect(value).to.be.deep.equal(data)
-        done()
-      })
+    const validator = new Validator(data, schema)
+    validator.then(value => {
+      expect(value).to.be.deep.equal(data)
+      done()
     })
+  })
 
-    it('Should catch errors an send them to the catch function', function (done) {
-      this.slow(1000)
-      const data = { key: 235 }
-      const schema = {
-        key: async value => {
-          await sleep(100)
+  it('Should catch errors an send them to the catch function', function (done) {
+    this.slow(1000)
+    const data = { key: 235 }
+    const schema = {
+      key: async value => {
+        await sleep(100)
 
-          if (typeof value !== 'string') {
-            throw new Error('should be a string')
-          }
-
-          return true
+        if (typeof value !== 'string') {
+          throw new Error('should be a string')
         }
-      }
 
-      const validator = new Validator(data, schema)
-      validator.catch(error => {
-        expect(error).to.be.deep.equal({ key: 'should be a string' })
-        done()
-      })
+        return true
+      }
+    }
+
+    const validator = new Validator(data, schema)
+    validator.catch(error => {
+      expect(error).to.be.deep.equal({ key: 'should be a string' })
+      done()
     })
-  }
+  })
 })


### PR DESCRIPTION
Enable async types with the `AsyncFunction`, closes #6 
```js
const schema = {
  target: async value => await someAsyncFunction() 
}
```